### PR TITLE
Fix conflicting type arguments error

### DIFF
--- a/examples/src/main/java/org/bindgen/example/ConflictingTypeArguments.java
+++ b/examples/src/main/java/org/bindgen/example/ConflictingTypeArguments.java
@@ -1,0 +1,20 @@
+package org.bindgen.example;
+
+import org.bindgen.Bindable;
+
+@Bindable
+public class ConflictingTypeArguments<ROOT, PARENT, ROOT_TYPE, PARENT_TYPE, R_0, P_0,
+    A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z> {
+
+    public ConflictingTypeArguments<ROOT, PARENT, ROOT_TYPE, PARENT_TYPE, R_0, P_0,
+            A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z> property;
+
+    public ConflictingTypeArguments<ROOT, PARENT, ROOT_TYPE, PARENT_TYPE, R_0, P_0,
+            A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z> getAnotherProperty() {
+        return null;
+    }
+
+    public void setAnotherProperty(ConflictingTypeArguments<ROOT, PARENT, ROOT_TYPE, PARENT_TYPE, R_0, P_0,
+            A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z> property) {}
+
+}

--- a/processor/src/main/java/org/bindgen/processor/generators/BindingClassGenerator.java
+++ b/processor/src/main/java/org/bindgen/processor/generators/BindingClassGenerator.java
@@ -5,16 +5,14 @@ import static org.bindgen.processor.CurrentEnv.*;
 import java.io.IOException;
 import java.io.Writer;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import javax.annotation.Generated;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.JavaFileObject;
 
@@ -52,6 +50,7 @@ public class BindingClassGenerator {
 	private final BoundClass name;
 	private final List<String> foundSubBindings = new ArrayList<String>();
 	private final Set<Element> sourceElements = new HashSet<Element>();
+
 	private GClass pathBindingClass;
 	private GClass rootBindingClass;
 
@@ -108,20 +107,36 @@ public class BindingClassGenerator {
 		// - Getter<P, T> getter
 		// - Setter<P, T> setter
 		// call parent constructor with same args
+
+		final String rootTypeArgument = name.getRootTypeArgument();
+		final String parentTypeArgument = name.getParentTypeArgument();
+
 		this.pathBindingClass.getConstructor(new Argument(String.class.getName(), "name"),
-				new Argument(String.format("%s<?>", Class.class.getName()), "type"),
-				new Argument(String.format("%s<R, P>", BindingRoot.class.getName()), "parentBinding"),
-				new Argument(String.format("%s<P, %s>", Getter.class.getName(), this.name.get().toString()), "getter"),
-				new Argument(String.format("%s<P, %s>", Setter.class.getName(), this.name.get().toString()), "setter"))
+				new Argument(String.format("%1$s<?>", Class.class.getName()), "type"),
+				new Argument(
+					String.format("%1$s<%2$s, %3$s>", BindingRoot.class.getName(), rootTypeArgument, parentTypeArgument),
+					"parentBinding"),
+				new Argument(
+					String.format("%1$s<%3$s, %2$s>", Getter.class.getName(), this.name.get().toString(), parentTypeArgument),
+					"getter"),
+				new Argument(
+					String.format("%1$s<%3$s, %2$s>", Setter.class.getName(), this.name.get().toString(), parentTypeArgument),
+					"setter"))
 				.setBody("super(name, type, parentBinding, getter, setter);\n");
 		// another constructor without type argument
 		this.pathBindingClass.getConstructor(new Argument(String.class.getName(), "name"),
-				new Argument(String.format("%s<R, P>", BindingRoot.class.getName()), "parentBinding"),
-				new Argument(String.format("%s<P, %s>", Getter.class.getName(), this.name.get().toString()), "getter"),
-				new Argument(String.format("%s<P, %s>", Setter.class.getName(), this.name.get().toString()), "setter"))
+				new Argument(
+					String.format("%1$s<%3$s, %2$s>", Getter.class.getName(), this.name.get().toString(), parentTypeArgument),
+					"getter"),
+				new Argument(
+					String.format("%1$s<%2$s, %3$s>", BindingRoot.class.getName(), rootTypeArgument, parentTypeArgument),
+					"parentBinding"),
+				new Argument(
+					String.format("%1$s<%3$s, %2$s>", Setter.class.getName(), this.name.get().toString(), parentTypeArgument),
+					"setter"))
 				.setBody("super(name, parentBinding, getter, setter);\n");
 		// same only with type
-		this.pathBindingClass.getConstructor(new Argument(String.format("%s<?>", Class.class.getName()), "type"))
+		this.pathBindingClass.getConstructor(new Argument(String.format("%1$s<?>", Class.class.getName()), "type"))
 				.setBody("super(type);\n");
 	}
 

--- a/processor/src/main/java/org/bindgen/processor/generators/FieldPropertyGenerator.java
+++ b/processor/src/main/java/org/bindgen/processor/generators/FieldPropertyGenerator.java
@@ -168,14 +168,16 @@ public class FieldPropertyGenerator extends AbstractGenerator implements Propert
 
 	private void addInnerClassGetWithRoot() {
 		GMethod getWithRoot = this.innerClass.getMethod("getWithRoot");
-		getWithRoot.argument("R", "root").returnType(this.property.getSetType()).addAnnotation("@Override");
+		getWithRoot.argument(property.getBoundClass().getRootTypeArgument(), "root")
+			.returnType(this.property.getSetType()).addAnnotation("@Override");
 		getWithRoot.body.line("return {}{}.this.getWithRoot(root).{};", //
 				this.property.getCastForReturnIfNeeded(), this.outerClass.getSimpleName(), this.fieldName);
 	}
 
 	private void addInnerClassGetSafelyWithRoot() {
 		GMethod m = this.innerClass.getMethod("getSafelyWithRoot");
-		m.argument("R", "root").returnType(this.property.getSetType()).addAnnotation("@Override");
+		m.argument(property.getBoundClass().getRootTypeArgument(), "root")
+			.returnType(this.property.getSetType()).addAnnotation("@Override");
 		m.body.line("if ({}.this.getSafelyWithRoot(root) == null) {", this.outerClass.getSimpleName());
 		m.body.line("    return null;");
 		m.body.line("} else {");
@@ -196,8 +198,11 @@ public class FieldPropertyGenerator extends AbstractGenerator implements Propert
 	}
 
 	private void addInnerClassSetWithRoot() {
-		GMethod setWithRoot = this.innerClass.getMethod("setWithRoot(R root, {} {})", this.property.getSetType(),
-				this.property.getName());
+		GMethod setWithRoot = this.innerClass.getMethod("setWithRoot({} root, {} {})",
+			property.getBoundClass().getRootTypeArgument(),
+			this.property.getSetType(),
+			this.property.getName()
+		);
 		setWithRoot.addAnnotation("@Override");
 		if (this.isFinal) {
 			setWithRoot.body.line("throw new RuntimeException(this.getName() + \" is read only\");");

--- a/processor/src/main/java/org/bindgen/processor/generators/MethodPropertyGenerator.java
+++ b/processor/src/main/java/org/bindgen/processor/generators/MethodPropertyGenerator.java
@@ -215,14 +215,16 @@ public class MethodPropertyGenerator extends AbstractGenerator implements Proper
 
 	private void addInnerClassGetWithRoot() {
 		GMethod getWithRoot = this.innerClass.getMethod("getWithRoot");
-		getWithRoot.argument("R", "root").returnType(this.property.getSetType()).addAnnotation("@Override");
+		getWithRoot.argument(boundClass.getRootTypeArgument(), "root")
+			.returnType(this.property.getSetType()).addAnnotation("@Override");
 		getWithRoot.body.line("return {}{}.this.getWithRoot(root).{}();", //
 				this.property.getCastForReturnIfNeeded(), this.outerClass.getSimpleName(), this.methodName);
 	}
 
 	private void addInnerClassGetSafelyWithRoot() {
 		GMethod m = this.innerClass.getMethod("getSafelyWithRoot");
-		m.argument("R", "root").returnType(this.property.getSetType()).addAnnotation("@Override");
+		m.argument(boundClass.getRootTypeArgument(), "root")
+			.returnType(this.property.getSetType()).addAnnotation("@Override");
 		m.body.line("if ({}.this.getSafelyWithRoot(root) == null) {", this.outerClass.getSimpleName());
 		m.body.line("    return null;");
 		m.body.line("} else {");
@@ -239,8 +241,11 @@ public class MethodPropertyGenerator extends AbstractGenerator implements Proper
 	}
 
 	private void addReadOnlyInnerClassSetWithRoot() {
-		GMethod setWithRoot = this.innerClass.getMethod("setWithRoot(R root, {} {})", this.property.getSetType(),
-				this.property.getName());
+		GMethod setWithRoot = this.innerClass.getMethod("setWithRoot({} root, {} {})",
+			boundClass.getRootTypeArgument(),
+			this.property.getSetType(),
+			this.property.getName()
+		);
 		setWithRoot.addAnnotation("@Override");
 		setWithRoot.body.line("throw new RuntimeException(this.getName() + \" is read only\");");
 	}
@@ -257,8 +262,11 @@ public class MethodPropertyGenerator extends AbstractGenerator implements Proper
 	}
 
 	private void addInnerClassSetWithRoot() {
-		GMethod setWithRoot = this.innerClass.getMethod("setWithRoot(R root, {} {})", this.property.getSetType(),
-				this.property.getName());
+		GMethod setWithRoot = this.innerClass.getMethod("setWithRoot({} root, {} {})",
+			boundClass.getRootTypeArgument(),
+			this.property.getSetType(),
+			this.property.getName()
+		);
 		setWithRoot.addAnnotation("@Override");
 		setWithRoot.body.line("{}.this.getWithRoot(root).{}({});", //
 				this.outerClass.getSimpleName(), this.prefix.setterName(this.methodName), this.property.getName());

--- a/processor/src/main/java/org/bindgen/processor/util/BoundClass.java
+++ b/processor/src/main/java/org/bindgen/processor/util/BoundClass.java
@@ -2,9 +2,15 @@ package org.bindgen.processor.util;
 
 import static org.bindgen.processor.CurrentEnv.*;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
 
 import org.bindgen.processor.CurrentEnv;
 
@@ -18,14 +24,56 @@ public class BoundClass {
 
 	private final TypeElement element;
 	private final ClassName name;
+	private final String rootTypeArgument;
+	private final String parentTypeArgument;
 
 	public BoundClass(TypeElement element) {
 		this.element = element;
 		this.name = new ClassName(Util.boxIfNeeded(element.asType()).toString());
+		this.parentTypeArgument = findAvailableTypeArgumentName(element, "P", "PARENT", "PARENT_TYPE");
+		this.rootTypeArgument = findAvailableTypeArgumentName(element, "R", "ROOT", "ROOT_TYPE");
+	}
+
+	private String findAvailableTypeArgumentName(TypeElement element, String... suggestedNames) {
+		if (suggestedNames.length < 1) {
+			throw new IllegalArgumentException("suggested names should contain at least one element");
+		}
+		final LinkedHashSet<String> availableNames = new LinkedHashSet<>();
+		availableNames.addAll(Arrays.asList(suggestedNames));
+		final Set<String> usedNames = element.getTypeParameters()
+			.stream()
+			.map(TypeParameterElement::getSimpleName)
+			.map(Name::toString)
+			.collect(Collectors.toSet());
+		availableNames.removeAll(usedNames);
+
+		if (!availableNames.isEmpty()) {
+			return availableNames.iterator().next();
+		} else {
+			String template = suggestedNames[0] + "_%d";
+			int i=0;
+			String result;
+			while (usedNames.contains(result = String.format(template, i))) {
+				i++;
+			}
+			return result;
+		}
+//		element.getTypeParameters()
+//			.stream()
+//			.flatMap(typeParameterElement -> typeParameterElement.asType().
+//				.stream())
 	}
 
 	public boolean hasGenerics() {
 		return !this.element.getTypeParameters().isEmpty();
+	}
+
+	public String getParentTypeArgument() {
+		return parentTypeArgument;
+	}
+
+	public String getRootTypeArgument() {
+		return rootTypeArgument;
 	}
 
 	/**
@@ -39,13 +87,14 @@ public class BoundClass {
 
 	public String getBindingPathClassDeclaration() {
 		List<String> typeArgs = this.name.getGenericsWithBounds();
-		typeArgs.add(0, "R");
-		typeArgs.add(1, "P");
+		typeArgs.add(0, rootTypeArgument);
+		typeArgs.add(1, parentTypeArgument);
 		return this.getBindingClassName().getWithoutGenericPart() + "Path" + "<" + Join.commaSpace(typeArgs) + ">";
 	}
 
 	public String getBindingPathClassSuperClass() {
-		return CurrentEnv.getConfig().bindingPathSuperClassName() + "<R, P, " + this.name.get() + ">";
+		return String.format("%1s<%2s, %3s, %4s>",
+			CurrentEnv.getConfig().bindingPathSuperClassName(), rootTypeArgument, parentTypeArgument, this.name.get());
 	}
 
 	public String getBindingRootClassDeclaration() {

--- a/processor/src/main/java/org/bindgen/processor/util/BoundClass.java
+++ b/processor/src/main/java/org/bindgen/processor/util/BoundClass.java
@@ -58,10 +58,6 @@ public class BoundClass {
 			}
 			return result;
 		}
-//		element.getTypeParameters()
-//			.stream()
-//			.flatMap(typeParameterElement -> typeParameterElement.asType().
-//				.stream())
 	}
 
 	public boolean hasGenerics() {

--- a/processor/src/main/java/org/bindgen/processor/util/BoundProperty.java
+++ b/processor/src/main/java/org/bindgen/processor/util/BoundProperty.java
@@ -192,14 +192,22 @@ public class BoundProperty {
 	private String getInnerClassSuperClass(boolean replaceWildcards) {
 		// Arrays don't have individual binding classes
 		if (this.isArray()) {
-			return getConfig().bindingPathSuperClassName() + "<R, " + this.boundClass.get() + ", "
-					+ this.type.toString() + ">";
+			return String.format("%s<%s, %s, %s>",
+				getConfig().bindingPathSuperClassName(),
+				this.boundClass.getRootTypeArgument(),
+				this.boundClass.get(),
+				this.type.toString()
+			);
 		}
 		// Being a generic type, we have no XxxBindingPath to extend, so just
 		// extend AbstractBinding directly
 		if (this.isForGenericTypeParameter()) {
-			return getConfig().bindingPathSuperClassName() + "<R, " + this.boundClass.get() + ", "
-					+ this.getGenericElement() + ">";
+			return String.format("%s<%s, %s, %s>",
+				getConfig().bindingPathSuperClassName(),
+				this.boundClass.getRootTypeArgument(),
+				this.boundClass.get(),
+				this.getGenericElement()
+			);
 		}
 
 		// if our type is outside the binding scope and no existing binding is
@@ -219,13 +227,17 @@ public class BoundProperty {
 																							// use
 																							// it
 		) {
-			return GenericObjectBindingPath.class.getName() + "<R, " + this.boundClass.get() + ", "
-					+ this.type.toString() + ">";
+			return String.format("%s<%s, %s, %s, %s>",
+				GenericObjectBindingPath.class.getName(),
+				this.boundClass.getRootTypeArgument(),
+				this.boundClass.get(),
+				this.type.toString()
+			);
 		}
 
 		String superName = Util.lowerCaseOuterClassNames(this.element,
 				getConfig().baseNameForBinding(this.name) + "BindingPath");
-		List<String> typeArgs = Copy.list("R", this.boundClass.get());
+		List<String> typeArgs = Copy.list(this.boundClass.getRootTypeArgument(), this.boundClass.get());
 		if (this.isRawType()) {
 			for (TypeParameterElement tpe : this.getElement().getTypeParameters()) {
 				typeArgs.add(replaceWildcards ? "?" : tpe.toString());
@@ -272,6 +284,10 @@ public class BoundProperty {
 			}
 		}
 		return this.get();
+	}
+
+	public BoundClass getBoundClass() {
+		return boundClass;
 	}
 
 	public String getName() {


### PR DESCRIPTION
This patch fixes the conflicting type arguments error when generating
bindings for generic types that use R or P as type arguments, described
at: https://github.com/igloo-project/bindgen/issues/3

The changed behavior will look through a list of preferred type argument
names for both the root and path type arguments, and will pick the first
available one. In case the preferred list of type argument names is
exhausted, it will generate one with the first preferred type argument
name, combined with a number, so that the newly generated name is not
conflicting with any of the type argument names that are already used by
the type for which the binding is generated. The preferred name for the
bindings are:

 - R, ROOT, ROOT_TYPE, or the first available from R_1, R_2, etc.
 - P, PATH, PATH_TYPE, or the first available from P_1, P_2, etc.