### PR TITLE
Fix problem resolving bindgen.properties in a path containing spaces

### DIFF
--- a/processor/src/main/java/org/bindgen/processor/util/ConfUtil.java
+++ b/processor/src/main/java/org/bindgen/processor/util/ConfUtil.java
@@ -69,7 +69,7 @@ public class ConfUtil {
 		}
 
 		final Optional<InputStream> bindingPropertiesInAncestorPaths = pathsToRoot(baseUrl.getPath())
-			//skip the path that still contains the filename - we're gonna append that to every parent path anyway
+			// Skip the path that still contains the filename - we're gonna append that to every parent path anyway
 			.skip(1)
 			.map(newPath -> {
 				try {
@@ -106,7 +106,7 @@ public class ConfUtil {
 			.limit(pathComponents.size())
 			.boxed()
 			.map(i -> pathComponents.subList(0, i))
-			.filter(list -> !Arrays.asList("").equals(list)) //filter out empty path component before leading /
+			.filter(list -> !Arrays.asList("").equals(list)) // Filter out empty path component before leading /
 			.map(list -> list.stream()
 				.collect(Collectors.joining("/")));
 		return pathsToRoot;

--- a/processor/src/main/java/org/bindgen/processor/util/ConfUtil.java
+++ b/processor/src/main/java/org/bindgen/processor/util/ConfUtil.java
@@ -101,8 +101,7 @@ public class ConfUtil {
 	}
 
 	static Stream<String> pathsToRoot(String path) {
-		final List<String> componentsWithFile = Arrays.asList(path.split("/"));
-		final List<String> pathComponents = componentsWithFile.subList(0, componentsWithFile.size());
+		final List<String> pathComponents = Arrays.asList(path.split("/"));
 		final Stream<String> pathsToRoot = IntStream.iterate(pathComponents.size(), i -> i - 1)
 			.limit(pathComponents.size())
 			.boxed()

--- a/processor/src/test/java/org/bindgen/processor/util/ConfUtilTest.java
+++ b/processor/src/test/java/org/bindgen/processor/util/ConfUtilTest.java
@@ -1,0 +1,31 @@
+package org.bindgen.processor.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Nándor Előd Fekete
+ */
+public class ConfUtilTest {
+
+	@Test
+	public void testPathsToRoot() {
+		String testPath = "a/b/dummy.txt";
+		final List<String> result = ConfUtil.pathsToRoot(testPath)
+			.collect(Collectors.toList());
+		Assert.assertEquals(Arrays.asList("a/b/dummy.txt", "a/b", "a"), result);
+	}
+
+	@Test
+	public void testPathsToRootWithLeadingSlash() {
+		String testPath = "/a/b/dummy.txt";
+		final List<String> result = ConfUtil.pathsToRoot(testPath)
+			.collect(Collectors.toList());
+		Assert.assertEquals(Arrays.asList("/a/b/dummy.txt", "/a/b", "/a"), result);
+	}
+
+}

--- a/processor/src/test/java/org/bindgen/processor/util/ConfUtilTest.java
+++ b/processor/src/test/java/org/bindgen/processor/util/ConfUtilTest.java
@@ -3,6 +3,9 @@ package org.bindgen.processor.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -12,20 +15,44 @@ import java.util.stream.Collectors;
  */
 public class ConfUtilTest {
 
-	@Test
-	public void testPathsToRoot() {
-		String testPath = "a/b/dummy.txt";
-		final List<String> result = ConfUtil.pathsToRoot(testPath)
-			.collect(Collectors.toList());
-		Assert.assertEquals(Arrays.asList("a/b/dummy.txt", "a/b", "a"), result);
-	}
+    @Test
+    public void testRelativePathParents() {
+        final Path testPath = Paths.get("a", "b", "dummy.txt");
+        final List<Path> result = ConfUtil.pathWithParents(testPath)
+            .collect(Collectors.toList());
+        Assert.assertEquals(
+            Arrays.asList(
+                testPath,
+                testPath.getParent(),
+                testPath.getParent()
+                    .getParent()
+            ),
+            result
+        );
+    }
 
-	@Test
-	public void testPathsToRootWithLeadingSlash() {
-		String testPath = "/a/b/dummy.txt";
-		final List<String> result = ConfUtil.pathsToRoot(testPath)
-			.collect(Collectors.toList());
-		Assert.assertEquals(Arrays.asList("/a/b/dummy.txt", "/a/b", "/a"), result);
-	}
+    @Test
+    public void testAbsolutePathParents() {
+        final Iterable<Path> rootDirectories = FileSystems.getDefault()
+            .getRootDirectories();
+        /*
+            The test is going to fail if the security manager denies access to all filesystem roots
+            or there are no filesystem roots in the running system (not sure if that's possible).
+        */
+        final Path rootDirectory = rootDirectories.iterator()
+            .next();
+        final Path testPath = rootDirectory.resolve(Paths.get("a", "b", "dummy.txt"));
+        final List<Path> result = ConfUtil.pathWithParents(testPath)
+            .collect(Collectors.toList());
+        Assert.assertEquals(
+            Arrays.asList(
+                rootDirectory.resolve(Paths.get("a", "b", "dummy.txt")),
+                rootDirectory.resolve(Paths.get("a", "b")),
+                rootDirectory.resolve(Paths.get("a")),
+                rootDirectory
+            ),
+            result
+        );
+    }
 
 }


### PR DESCRIPTION
This commit fixes https://github.com/igloo-project/bindgen/issues/12

I replaced the URI + File based code with just URIs when trying to
resolve bindgen.properties. The code works by creating new URIs based on
the original URI returned by the Filer with ever shorter paths,
component by component. Semantically, I kept the old behavior of
scanning all the possible paths up until the filesystem root, so it
doesn't break projects that rely on this behavior.