### PR TITLE
fix getType() method on bindings

### DIFF
--- a/examples/src/main/java/org/bindgen/example/access/BindingClashes.java
+++ b/examples/src/main/java/org/bindgen/example/access/BindingClashes.java
@@ -5,6 +5,8 @@ import org.bindgen.Bindable;
 @Bindable
 public class BindingClashes {
 
+	public String property = "0";
+
 	public String type() {
 		return "1";
 	}

--- a/examples/src/test/java/org/bindgen/example/access/BindingClashesTest.java
+++ b/examples/src/test/java/org/bindgen/example/access/BindingClashesTest.java
@@ -10,7 +10,9 @@ public class BindingClashesTest extends TestCase {
 
 		assertEquals(BindingClashes.class, b.getType());
 		assertEquals("1", b.type().get());
+		assertEquals(String.class, b.type().getType());
 		assertEquals("2", b.getTypeBinding().get());
+		assertEquals(String.class, b.property().getType());
 	}
 
 	public void testPath() {

--- a/processor/src/main/java/org/bindgen/processor/generators/MethodPropertyGenerator.java
+++ b/processor/src/main/java/org/bindgen/processor/generators/MethodPropertyGenerator.java
@@ -153,7 +153,7 @@ public class MethodPropertyGenerator extends AbstractGenerator implements Proper
 				setterLambda = "(item, value) -> item.{}(value)";
 			}
 
-			if (!this.property.shouldGenerateBindingClassForType() && !this.property.existsFieldTypeBindingFor()) {
+			if (!"null".equals(type)) {
 				fieldGet.body.line(
 						String.format("    this.{} = new {}(\"{}\", {}, this, (item) -> item.{}(), %s);", setterLambda),
 						this.property.getName(), this.property.getInnerClassSuperClass(), this.property.getName(), type,


### PR DESCRIPTION
In 3987449dad7b4598d6b1375b3211ab917b01c79e, getType() is broken for
some field bindings.

getType() was previously implemented on each generated binding. This was
changed to provide type at \*BindingPath construction time. getType()
value is now stored in bindingType attribute.

But MethodPropertyGenerator.java do not always build a new
\*BindingPath(...) with a type parameter, as it should.

This patch now always passes a type argument if it is available, except
for Array (not sure about it should or should not for this case, so I do
not modify this case).