### PR TITLE
Fix problem handling annotated types on type use - continued

### DIFF
--- a/processor/src/main/java/org/bindgen/processor/generators/BindKeywordGenerator.java
+++ b/processor/src/main/java/org/bindgen/processor/generators/BindKeywordGenerator.java
@@ -26,6 +26,7 @@ import org.bindgen.processor.GenerationQueue;
 import org.bindgen.processor.Processor;
 import org.bindgen.processor.util.BoundClass;
 import org.bindgen.processor.util.ClassName;
+import org.bindgen.processor.util.Util;
 
 /** Generates a BindKeyword class with "bind" static helper methods.
  *
@@ -86,7 +87,7 @@ public class BindKeywordGenerator {
 		if (type.getTypeArguments().size() > 0) {
 			GMethod method = this.bindClass.getMethod("bind({}<{}> o)", className, Join.commaSpace(bindingType.getGenericPartWithoutBrackets()));
 			method.returnType("{}", bindingType);
-			method.typeParameters(Join.commaSpace(new ClassName(type.toString()).getGenericsWithBounds()));
+			method.typeParameters(Join.commaSpace(new ClassName(Util.getTypeName(type)).getGenericsWithBounds()));
 			method.setStatic();
 			method.body.line("return new {}(o);", bindingType);
 		} else {

--- a/processor/src/main/java/org/bindgen/processor/generators/MethodCallableGenerator.java
+++ b/processor/src/main/java/org/bindgen/processor/generators/MethodCallableGenerator.java
@@ -112,7 +112,7 @@ public class MethodCallableGenerator extends AbstractGenerator implements Proper
 
 	private void addInnerClassMethod() {
 		GMethod run = this.innerClass.getMethod(this.blockMethod.getSimpleName().toString());
-		run.returnType(this.blockMethod.getReturnType().toString());
+		run.returnType(Util.getTypeName(this.blockMethod.getReturnType()));
 		run.body.line("{}{}.this.get().{}({});", //
 				this.getReturnPrefixIfNeeded(), this.outerClass.getSimpleName(), this.methodName, this.getArguments());
 		this.addMethodParameters(run);
@@ -174,13 +174,13 @@ public class MethodCallableGenerator extends AbstractGenerator implements Proper
 
 	private void addMethodParameters(GMethod run) {
 		for (VariableElement foo : this.blockMethod.getParameters()) {
-			run.argument(foo.asType().toString(), foo.getSimpleName().toString());
+			run.argument(Util.getTypeName(foo.asType()), foo.getSimpleName().toString());
 		}
 	}
 
 	private void addMethodThrows(GMethod run) {
 		for (TypeMirror type : this.method.getThrownTypes()) {
-			run.addThrows(type.toString());
+			run.addThrows(Util.getTypeName(type));
 		}
 	}
 

--- a/processor/src/main/java/org/bindgen/processor/util/BoundClass.java
+++ b/processor/src/main/java/org/bindgen/processor/util/BoundClass.java
@@ -29,7 +29,7 @@ public class BoundClass {
 
 	public BoundClass(TypeElement element) {
 		this.element = element;
-		this.name = new ClassName(Util.boxIfNeeded(element.asType()).toString());
+		this.name = new ClassName(Util.getTypeName(Util.boxIfNeeded(element.asType())));
 		this.parentTypeArgument = findAvailableTypeArgumentName(element, "P", "PARENT", "PARENT_TYPE");
 		this.rootTypeArgument = findAvailableTypeArgumentName(element, "R", "ROOT", "ROOT_TYPE");
 	}

--- a/processor/src/main/java/org/bindgen/processor/util/BoundProperty.java
+++ b/processor/src/main/java/org/bindgen/processor/util/BoundProperty.java
@@ -162,7 +162,7 @@ public class BoundProperty {
 					if (wildcard.extendsBound != null) {
 						// the user declared their own bounds, e.g. "public
 						// Foo<? extends Foo<?>> foo"
-						suffix += " extends " + wildcard.extendsBound.toString();
+						suffix += " extends " + Util.getTypeName(wildcard.extendsBound);
 					} else if (wildcard.wildcardParameter != null) {
 						suffix += " extends " + toStringWithDummyParam(wildcard.wildcardParameter.getBounds().get(0),
 								wildcard.wildcardParameter.asType(), wildcard.dummyParam, dummyTypes);
@@ -196,7 +196,7 @@ public class BoundProperty {
 				getConfig().bindingPathSuperClassName(),
 				this.boundClass.getRootTypeArgument(),
 				this.boundClass.get(),
-				this.type.toString()
+				this.name
 			);
 		}
 		// Being a generic type, we have no XxxBindingPath to extend, so just
@@ -213,25 +213,14 @@ public class BoundProperty {
 		// if our type is outside the binding scope and no existing binding is
 		// available,
 		// we return a generic binding type
-		if (!this.shouldGenerateBindingClassForType() && !this.existsFieldTypeBindingFor() // check
-																							// if
-																							// type
-																							// binding
-																							// already
-																							// exists
-																							// ;
-																							// if
-																							// so,
-																							// we
-																							// can
-																							// use
-																							// it
-		) {
+
+		// check if type binding already exists;if so, we can use it
+		if (!this.shouldGenerateBindingClassForType() && !this.existsFieldTypeBindingFor()) {
 			return String.format("%s<%s, %s, %s>",
 				GenericObjectBindingPath.class.getName(),
 				this.boundClass.getRootTypeArgument(),
 				this.boundClass.get(),
-				this.type.toString()
+				this.name
 			);
 		}
 
@@ -250,7 +239,7 @@ public class BoundProperty {
 				if (tm.getKind() == TypeKind.WILDCARD) {
 					typeArgs.add(replaceWildcards ? "?" : ("U" + wildcardIndex++));
 				} else {
-					typeArgs.add(tm.toString());
+					typeArgs.add(Util.getTypeName(tm));
 				}
 			}
 		}
@@ -268,7 +257,7 @@ public class BoundProperty {
 					if (tm.getKind() == TypeKind.WILDCARD) {
 						dummyParams.add("U" + (wildcardIndex++));
 					} else {
-						dummyParams.add(tm.toString());
+						dummyParams.add(Util.getTypeName(tm));
 					}
 				}
 			}
@@ -375,7 +364,7 @@ public class BoundProperty {
 	private boolean fixRawTypeIfNeeded() {
 		String fixedTypeParameter = getConfig().fixedRawType(this.enclosing, this.propertyName);
 		if (!this.hasGenerics() && fixedTypeParameter != null) {
-			this.name = new ClassName(this.type.toString() + "<" + fixedTypeParameter + ">");
+			this.name = new ClassName(this.name + "<" + fixedTypeParameter + ">");
 			return true;
 		}
 		return false;
@@ -443,7 +432,7 @@ public class BoundProperty {
 				params.add(toStringWithDummyParam(ta, tp, dummyParameter, dummyTypes));
 			}
 			if (params.size() == 0) {
-				return tm.toString();
+				return Util.getTypeName(tm);
 			} else {
 				return dt.asElement().toString() + "<" + Join.commaSpace(params) + ">";
 			}
@@ -452,7 +441,7 @@ public class BoundProperty {
 			return dummyParameter;
 		}
 		String existingDummy = dummyTypes.get(tm);
-		return existingDummy == null ? tm.toString() : existingDummy;
+		return existingDummy == null ? Util.getTypeName(tm) : existingDummy;
 	}
 
 	private static class WildcardTypeData {

--- a/processor/src/main/java/org/bindgen/processor/util/ClassName.java
+++ b/processor/src/main/java/org/bindgen/processor/util/ClassName.java
@@ -65,7 +65,7 @@ public class ClassName {
 	public List<String> getGenericsWithoutBounds() {
 		List<String> args = new ArrayList<String>();
 		for (TypeMirror tv : this.getDeclaredType().getTypeArguments()) {
-			args.add(tv.toString());
+			args.add(Util.getTypeName(tv));
 		}
 		return args;
 	}
@@ -79,9 +79,9 @@ public class ClassName {
 		@SuppressWarnings("unchecked")
 		List<TypeVariable> typeVariables = (List<TypeVariable>) this.getDeclaredType().getTypeArguments();
 		for (TypeVariable tv : typeVariables) {
-			String arg = tv.toString();
+			String arg = Util.getTypeName(tv);
 			if (!Util.isOfTypeObjectOrNone(tv.getUpperBound())) {
-				arg += " extends " + tv.getUpperBound().toString();
+				arg += " extends " + Util.getTypeName(tv.getUpperBound());
 			}
 			args.add(arg);
 		}

--- a/processor/src/main/java/org/bindgen/processor/util/Util.java
+++ b/processor/src/main/java/org/bindgen/processor/util/Util.java
@@ -58,7 +58,7 @@ public class Util {
 	}
 
 	public static boolean isOfTypeObjectOrNone(TypeMirror type) {
-		return type.getKind() == TypeKind.NONE || type.toString().equals("java.lang.Object");
+		return type.getKind() == TypeKind.NONE || Util.getTypeName(type).equals("java.lang.Object");
 	}
 
 	/**

--- a/processor/src/main/java/org/bindgen/processor/util/Util.java
+++ b/processor/src/main/java/org/bindgen/processor/util/Util.java
@@ -1,6 +1,7 @@
 package org.bindgen.processor.util;
 
-import static org.bindgen.processor.CurrentEnv.*;
+import static org.bindgen.processor.CurrentEnv.getElementUtils;
+import static org.bindgen.processor.CurrentEnv.getTypeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +17,7 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.SimpleTypeVisitor6;
+import javax.lang.model.util.SimpleTypeVisitor8;
 import javax.lang.model.util.Types;
 
 import joist.sourcegen.Access;
@@ -115,7 +116,7 @@ public class Util {
 	 * @return
 	 */
 	public static String getTypeName(TypeMirror type) {
-		return type.accept(new SimpleTypeVisitor6<String, Void>(type.toString()) {
+		return type.accept(new SimpleTypeVisitor8<String, Void>(type.toString()) {
 
 			@Override
 			public String visitDeclared(DeclaredType t, Void p) {

--- a/processor/src/test/java/org/bindgen/processor/AnnotatedTypeUseTest.java
+++ b/processor/src/test/java/org/bindgen/processor/AnnotatedTypeUseTest.java
@@ -1,0 +1,34 @@
+package org.bindgen.processor;
+
+import org.junit.Test;
+
+/**
+ * @author Nándor Előd Fekete
+ */
+public class AnnotatedTypeUseTest extends AbstractBindgenTestCase {
+
+    @Test
+    public void testAnnotatedTypeUse() throws Exception {
+        final ClassLoader cl = this.compile("org/bindgen/processor/annotatedtypeuse/TypeAnnotation.java",
+            "org/bindgen/processor/annotatedtypeuse/AnnotatedReturnType.java");
+        final Class<?> aClass = cl.loadClass("org.bindgen.processor.annotatedtypeuse.AnnotatedReturnTypeBinding");
+        assertChildBindings(aClass,
+            "hashCodeBinding", "toStringBinding", "annotatedTypeField",
+            "annotatedString");
+    }
+
+    @Test
+    public void testOutOfScopeAnnotatedTypeUse() throws Exception {
+        this.setScope("org.bindgen.processor.annotatedtypeuse");
+        final ClassLoader cl = this.compile("org/bindgen/processor/annotatedtypeuse/TypeAnnotation.java",
+            "org/bindgen/processor/annotatedtypeuse/AnnotatedReturnType.java",
+            "org/bindgen/processor/outofscope/OutOfScope.java");
+        final Class<?> aClass = cl.loadClass("org.bindgen.processor.annotatedtypeuse.AnnotatedReturnTypeBinding");
+        assertChildBindings(aClass,
+            "hashCodeBinding", "toStringBinding", "annotatedTypeField",
+            "annotatedString");
+    }
+
+
+
+}

--- a/processor/src/test/java/org/bindgen/processor/GenericsMultipleBoundsTest.java
+++ b/processor/src/test/java/org/bindgen/processor/GenericsMultipleBoundsTest.java
@@ -1,0 +1,22 @@
+package org.bindgen.processor;
+
+import org.junit.Test;
+
+public class GenericsMultipleBoundsTest extends AbstractBindgenTestCase {
+
+	/**
+	 * Test types with a multiple bounded (T extends Interface1 & Interface2)
+	 * generic definition.
+	 */
+	@Test
+	public void testMultipleBounds() throws Exception {
+		ClassLoader cl = this.compile(
+			"org/bindgen/processor/generic/MultipleBounds.java",
+			"org/bindgen/processor/generic/Interface1.java",
+			"org/bindgen/processor/generic/Interface2.java");
+
+		Class<?> multipleBoundsBindingClass = cl.loadClass("org.bindgen.processor.generic.MultipleBoundsBinding");
+		assertChildBindings(multipleBoundsBindingClass, "hashCodeBinding", "toStringBinding");
+	}
+
+}

--- a/processor/src/test/template/org/bindgen/processor/annotatedtypeuse/AnnotatedReturnType.java
+++ b/processor/src/test/template/org/bindgen/processor/annotatedtypeuse/AnnotatedReturnType.java
@@ -1,0 +1,24 @@
+package org.bindgen.processor.annotatedtypeuse;
+
+import org.bindgen.Bindable;
+
+@Bindable
+public class AnnotatedReturnType {
+
+    public @TypeAnnotation String annotatedTypeField;
+
+    private @TypeAnnotation String annotatedString;
+
+    public @TypeAnnotation String getAnnotatedString() {
+        return this.annotatedString;
+    }
+
+    public void setAnnotatedString(@TypeAnnotation String annotatedString) {
+        this.annotatedString = annotatedString;
+    }
+
+    @Override
+    public @TypeAnnotation String toString() {
+        return super.toString();
+    }
+}

--- a/processor/src/test/template/org/bindgen/processor/annotatedtypeuse/TypeAnnotation.java
+++ b/processor/src/test/template/org/bindgen/processor/annotatedtypeuse/TypeAnnotation.java
@@ -1,0 +1,11 @@
+package org.bindgen.processor.annotatedtypeuse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE_USE)
+public @interface TypeAnnotation {
+}

--- a/processor/src/test/template/org/bindgen/processor/generic/Interface1.java
+++ b/processor/src/test/template/org/bindgen/processor/generic/Interface1.java
@@ -1,0 +1,5 @@
+package org.bindgen.processor.generic;
+
+public interface Interface1 {
+
+}

--- a/processor/src/test/template/org/bindgen/processor/generic/Interface2.java
+++ b/processor/src/test/template/org/bindgen/processor/generic/Interface2.java
@@ -1,0 +1,5 @@
+package org.bindgen.processor.generic;
+
+public interface Interface2 {
+
+}

--- a/processor/src/test/template/org/bindgen/processor/generic/MultipleBounds.java
+++ b/processor/src/test/template/org/bindgen/processor/generic/MultipleBounds.java
@@ -1,0 +1,8 @@
+package org.bindgen.processor.generic;
+
+import org.bindgen.Bindable;
+
+@Bindable
+public class MultipleBounds<T extends Interface1 & Interface2> {
+
+}

--- a/processor/src/test/template/org/bindgen/processor/outofscope/OutOfScope.java
+++ b/processor/src/test/template/org/bindgen/processor/outofscope/OutOfScope.java
@@ -1,0 +1,7 @@
+package org.bindgen.processor.outofscope;
+
+public class OutOfScope {
+
+    public int value;
+
+}


### PR DESCRIPTION
The previous commit that supposed to fix the problem with annotated type
use under javac solved only some of the possible cases. Upon further
use, I faced another problem when an annotated type use was combined
with a type that was outside of bindgen's scope. In that case a
GenericObjectBinding was generated for the type and the problem
described in https://github.com/igloo-project/bindgen/issues/8 came back
in a slightly different form. I decided I'll try to do a better job this
time, so I decided to replace all invocations of TypeMirror.toString
with Util.getTypeName. Hopefully this will solve the issue completely.

I also added a JUnit test for the two cases I uncovered up to this
point.